### PR TITLE
Do not raise for missed sequence_number

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -4,7 +4,7 @@
       name: "default",
       strict: true,
       checks: [
-        {Credo.Check.Design.TagTODO, false},
+        {Credo.Check.Design.TagTODO, false}
       ]
     }
   ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}", ".credo.exs"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ ecto_sqlite3_extras-*.tar
 /tmp/
 /test_database.db
 /chinook.db-*
+/empty.db*
 /tmp*

--- a/lib/queries/sequence_number.ex
+++ b/lib/queries/sequence_number.ex
@@ -16,9 +16,6 @@ defmodule EctoSQLite3Extras.SequenceNumber do
     }
   end
 
-  # TODO(@orsinium): The query fails if the table doesn't exist.
-  # The table is created only when the first autoincrement column is created.
-  # Can we fix it without doing INSERTs?
   def query(_args \\ []) do
     """
     /* from ecto_sqlite3_extras */

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EctoSQLite3Extras.MixProject do
   use Mix.Project
   @github_url "https://github.com/orsinium-labs/ecto_sqlite3_extras"
-  @version "1.1.6"
+  @version "1.1.7"
 
   def project do
     [

--- a/test/ecto_sqlite3_extras_test.exs
+++ b/test/ecto_sqlite3_extras_test.exs
@@ -2,6 +2,7 @@ defmodule EctoSQLite3ExtrasTest do
   @moduledoc false
   use ExUnit.Case
   doctest EctoSQLite3Extras
+  alias EctoSQLite3Extras.EmptyTestRepo
   alias EctoSQLite3Extras.TestRepo
   import ExUnit.CaptureIO
 
@@ -33,6 +34,7 @@ defmodule EctoSQLite3ExtrasTest do
   describe "database interaction" do
     setup do
       start_supervised!(EctoSQLite3Extras.TestRepo)
+      start_supervised!(EctoSQLite3Extras.EmptyTestRepo)
       :ok
     end
 
@@ -44,6 +46,16 @@ defmodule EctoSQLite3ExtrasTest do
         names = Enum.map(info.columns, &Atom.to_string(&1.name))
         assert result.columns == names
         assert result.num_rows > 0
+      end
+    end
+
+    test "run queries on empty database" do
+      for query_name <- EctoSQLite3Extras.queries(EmptyTestRepo) |> Map.keys() do
+        result = EctoSQLite3Extras.query(query_name, EmptyTestRepo, format: :raw)
+        info = EctoSQLite3Extras.queries()[query_name].info
+        assert length(result.columns) == length(info.columns)
+        names = Enum.map(info.columns, &Atom.to_string(&1.name))
+        assert result.columns == names
       end
     end
 

--- a/test/test_repo.exs
+++ b/test/test_repo.exs
@@ -1,9 +1,21 @@
 defmodule EctoSQLite3Extras.TestRepo do
+  @moduledoc false
   use Ecto.Repo, otp_app: :ecto_sqlite3_extras, adapter: Ecto.Adapters.SQLite3
 
   def init(type, opts) do
     # https://www.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.zip
     opts = [database: "chinook.db"] ++ opts
+    opts[:parent] && send(opts[:parent], {__MODULE__, type, opts})
+    {:ok, opts}
+  end
+end
+
+defmodule EctoSQLite3Extras.EmptyTestRepo do
+  @moduledoc false
+  use Ecto.Repo, otp_app: :ecto_sqlite3_extras, adapter: Ecto.Adapters.SQLite3
+
+  def init(type, opts) do
+    opts = [database: "empty.db"] ++ opts
     opts[:parent] && send(opts[:parent], {__MODULE__, type, opts})
     {:ok, opts}
   end


### PR DESCRIPTION
The `sequence_number` table is created only with the first autoincrement column and so can be missed in the database, especially empty one. There is no simple way to suppress the error on the SQL query side.

The PR suppresses the error on the Elixir wrapper side.