### PR TITLE
Fix Elixir 1.17 runtime warning about parentheses

### DIFF
--- a/lib/ecto_sqlite3_extras.ex
+++ b/lib/ecto_sqlite3_extras.ex
@@ -87,7 +87,7 @@ defmodule EctoSQLite3Extras do
     |> run_query(sql_query, query_opts)
     |> unwrap()
     |> preformat()
-    |> format(format_name, query_module.info)
+    |> format(format_name, query_module.info())
   end
 
   # run query on a remote node

--- a/test/ecto_sqlite3_extras_test.exs
+++ b/test/ecto_sqlite3_extras_test.exs
@@ -41,7 +41,7 @@ defmodule EctoSQLite3ExtrasTest do
     test "run queries by param" do
       for query_name <- EctoSQLite3Extras.queries(TestRepo) |> Map.keys() do
         result = EctoSQLite3Extras.query(query_name, TestRepo, format: :raw)
-        info = EctoSQLite3Extras.queries()[query_name].info
+        info = EctoSQLite3Extras.queries()[query_name].info()
         assert length(result.columns) == length(info.columns)
         names = Enum.map(info.columns, &Atom.to_string(&1.name))
         assert result.columns == names
@@ -52,7 +52,7 @@ defmodule EctoSQLite3ExtrasTest do
     test "run queries on empty database" do
       for query_name <- EctoSQLite3Extras.queries(EmptyTestRepo) |> Map.keys() do
         result = EctoSQLite3Extras.query(query_name, EmptyTestRepo, format: :raw)
-        info = EctoSQLite3Extras.queries()[query_name].info
+        info = EctoSQLite3Extras.queries()[query_name].info()
         assert length(result.columns) == length(info.columns)
         names = Enum.map(info.columns, &Atom.to_string(&1.name))
         assert result.columns == names


### PR DESCRIPTION
Hello! I fixed the warning about invoking function without parentheses.
```
warning: using map.field notation (without parentheses) to invoke function EctoSQLite3Extras.CompileOptions.info() is deprecated, you must add parentheses instead: remote.function()
  (ecto_sqlite3_extras 1.2.2) lib/ecto_sqlite3_extras.ex:90: EctoSQLite3Extras.query/3
```
and same in tests
```
warning: using map.field notation (without parentheses) to invoke function EctoSQLite3Extras.CompileOptions.info() is deprecated, you must add parentheses instead: remote.function()
  test/ecto_sqlite3_extras_test.exs:44: anonymous fn/2 in EctoSQLite3ExtrasTest."test database interaction run queries by param"/1
```
```
warning: using map.field notation (without parentheses) to invoke function EctoSQLite3Extras.CompileOptions.info() is deprecated, you must add parentheses instead: remote.function()
  test/ecto_sqlite3_extras_test.exs:55: anonymous fn/2 in EctoSQLite3ExtrasTest."test database interaction run queries on empty database"/1
```